### PR TITLE
Reverse polyfill xhr <-> fetch

### DIFF
--- a/dist/worker/pusher.js
+++ b/dist/worker/pusher.js
@@ -601,7 +601,46 @@ var Pusher =
 /* 2 */
 /***/ function(module, exports) {
 
-	module.exports = XMLHttpRequest;
+	function FetchXHR() {
+	  this.options = {};
+	}
+
+	var prototype = FetchXHR.prototype;
+
+	prototype.open = function(method, url) {
+	  this.options.method = method;
+	  this.url = url;
+	}
+
+	prototype.setRequestHeader = function(key, value) {
+	  if (!this.options.headers) {
+	    var headers = {};
+	    headers[key] = value;
+	    this.options.headers = new Headers(headers);
+	  } else {
+	    this.options.headers.set(key, value);
+	  }
+	}
+
+	prototype.send = function(body) {
+	  this.options.body = body;
+	  var request = new Request(this.url, this.options);
+	  var self = this;
+
+	  fetch(request).then(function(response){
+	    self.readyState = 4;
+	    self.status = response.status;
+	    return response.text();
+	  }).then(function(text){
+	    self.responseText = text;
+	    if (self.onreadystatechange) self.onreadystatechange();
+	  }).catch(function(err){
+	    throw("Request failure: " + err);
+	  });
+	}
+
+
+	module.exports = FetchXHR;
 
 
 /***/ },

--- a/src/node_modules/pusher-websocket-iso-externals-worker/xhr.js
+++ b/src/node_modules/pusher-websocket-iso-externals-worker/xhr.js
@@ -1,1 +1,40 @@
-module.exports = XMLHttpRequest;
+function FetchXHR() {
+  this.options = {};
+}
+
+var prototype = FetchXHR.prototype;
+
+prototype.open = function(method, url) {
+  this.options.method = method;
+  this.url = url;
+}
+
+prototype.setRequestHeader = function(key, value) {
+  if (!this.options.headers) {
+    var headers = {};
+    headers[key] = value;
+    this.options.headers = new Headers(headers);
+  } else {
+    this.options.headers.set(key, value);
+  }
+}
+
+prototype.send = function(body) {
+  this.options.body = body;
+  var request = new Request(this.url, this.options);
+  var self = this;
+
+  fetch(request).then(function(response){
+    self.readyState = 4;
+    self.status = response.status;
+    return response.text();
+  }).then(function(text){
+    self.responseText = text;
+    if (self.onreadystatechange) self.onreadystatechange();
+  }).catch(function(err){
+    throw("Request failure: " + err);
+  });
+}
+
+
+module.exports = FetchXHR;


### PR DESCRIPTION
- XHR is deprecated for workers ( I think at least SharedWorkers and ServiceWorkers )
- However, they have the newer `fetch` API
- This is a reverse polyfill that implements `XMLHttpRequest` using `fetch` underneath.

WDYT @pl @jackfranklin ?
