### PR TITLE
Removing named module.exports

### DIFF
--- a/dist/react-native/pusher.js
+++ b/dist/react-native/pusher.js
@@ -243,9 +243,7 @@ module.exports =
 
 	function checkAppKey(key) {
 	  if (key === null || key === undefined) {
-	    Logger.warn(
-	      'Warning', 'You must pass your app key when you instantiate Pusher.'
-	    );
+	    throw "You must pass your app key when you instantiate Pusher.";
 	  }
 	}
 
@@ -261,7 +259,7 @@ module.exports =
 
 	var XHR = __webpack_require__(2);
 
-	module.exports = Util = {
+	module.exports = {
 	  now: function() {
 	    if (Date.now) {
 	      return Date.now();
@@ -1397,7 +1395,7 @@ module.exports =
 	  }
 	};
 
-	module.exports = getStreamingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -1665,7 +1663,7 @@ module.exports =
 	  }
 	};
 
-	module.exports = getXHR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1801,7 +1799,7 @@ module.exports =
 	  }
 	};
 
-	module.exports = getXDR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1831,7 +1829,7 @@ module.exports =
 	  }
 	};
 
-	module.exports = getPollingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -2539,7 +2537,7 @@ module.exports =
 	var IfStrategy = __webpack_require__(42);
 	var FirstConnectedStrategy = __webpack_require__(43);
 
-	module.exports = StrategyBuilder = {
+	module.exports = {
 	  /** Transforms a JSON scheme to a strategy tree.
 	   *
 	   * @param {Array} scheme JSON strategy scheme
@@ -4202,7 +4200,11 @@ module.exports =
 	  var previousState = this.state;
 	  this.state = newState;
 	  if (previousState !== newState) {
-	    Logger.debug('State changed', previousState + ' -> ' + newState);
+	    var newStateDescription = newState;
+	    if (newState === "connected") {
+	      newStateDescription += " with new socket ID " + data.socket_id;
+	    }
+	    Logger.debug('State changed', previousState + ' -> ' + newStateDescription);
 	    this.timeline.info({ state: newState, params: data });
 	    this.emit('state_change', { previous: previousState, current: newState });
 	    this.emit(newState, data);

--- a/dist/web-umd/pusher.js
+++ b/dist/web-umd/pusher.js
@@ -252,9 +252,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	function checkAppKey(key) {
 	  if (key === null || key === undefined) {
-	    Logger.warn(
-	      'Warning', 'You must pass your app key when you instantiate Pusher.'
-	    );
+	    throw "You must pass your app key when you instantiate Pusher.";
 	  }
 	}
 
@@ -270,7 +268,7 @@ return /******/ (function(modules) { // webpackBootstrap
 
 	/* WEBPACK VAR INJECTION */(function(global) {var XHR = __webpack_require__(2);
 
-	module.exports = Util = {
+	module.exports = {
 	  now: function() {
 	    if (Date.now) {
 	      return Date.now();
@@ -1408,7 +1406,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	module.exports = getStreamingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -1676,7 +1674,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	module.exports = getXHR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1820,7 +1818,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	module.exports = getXDR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1850,7 +1848,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	  }
 	};
 
-	module.exports = getPollingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -2558,7 +2556,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	var IfStrategy = __webpack_require__(42);
 	var FirstConnectedStrategy = __webpack_require__(43);
 
-	module.exports = StrategyBuilder = {
+	module.exports = {
 	  /** Transforms a JSON scheme to a strategy tree.
 	   *
 	   * @param {Array} scheme JSON strategy scheme
@@ -4221,7 +4219,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  var previousState = this.state;
 	  this.state = newState;
 	  if (previousState !== newState) {
-	    Logger.debug('State changed', previousState + ' -> ' + newState);
+	    var newStateDescription = newState;
+	    if (newState === "connected") {
+	      newStateDescription += " with new socket ID " + data.socket_id;
+	    }
+	    Logger.debug('State changed', previousState + ' -> ' + newStateDescription);
 	    this.timeline.info({ state: newState, params: data });
 	    this.emit('state_change', { previous: previousState, current: newState });
 	    this.emit(newState, data);

--- a/dist/web/pusher.js
+++ b/dist/web/pusher.js
@@ -243,9 +243,7 @@ var Pusher =
 
 	function checkAppKey(key) {
 	  if (key === null || key === undefined) {
-	    Logger.warn(
-	      'Warning', 'You must pass your app key when you instantiate Pusher.'
-	    );
+	    throw "You must pass your app key when you instantiate Pusher.";
 	  }
 	}
 
@@ -261,7 +259,7 @@ var Pusher =
 
 	/* WEBPACK VAR INJECTION */(function(global) {var XHR = __webpack_require__(2);
 
-	module.exports = Util = {
+	module.exports = {
 	  now: function() {
 	    if (Date.now) {
 	      return Date.now();
@@ -1399,7 +1397,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getStreamingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -1667,7 +1665,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getXHR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1811,7 +1809,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getXDR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1841,7 +1839,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getPollingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -2549,7 +2547,7 @@ var Pusher =
 	var IfStrategy = __webpack_require__(42);
 	var FirstConnectedStrategy = __webpack_require__(43);
 
-	module.exports = StrategyBuilder = {
+	module.exports = {
 	  /** Transforms a JSON scheme to a strategy tree.
 	   *
 	   * @param {Array} scheme JSON strategy scheme
@@ -4212,7 +4210,11 @@ var Pusher =
 	  var previousState = this.state;
 	  this.state = newState;
 	  if (previousState !== newState) {
-	    Logger.debug('State changed', previousState + ' -> ' + newState);
+	    var newStateDescription = newState;
+	    if (newState === "connected") {
+	      newStateDescription += " with new socket ID " + data.socket_id;
+	    }
+	    Logger.debug('State changed', previousState + ' -> ' + newStateDescription);
 	    this.timeline.info({ state: newState, params: data });
 	    this.emit('state_change', { previous: previousState, current: newState });
 	    this.emit(newState, data);

--- a/dist/worker/pusher.js
+++ b/dist/worker/pusher.js
@@ -243,9 +243,7 @@ var Pusher =
 
 	function checkAppKey(key) {
 	  if (key === null || key === undefined) {
-	    Logger.warn(
-	      'Warning', 'You must pass your app key when you instantiate Pusher.'
-	    );
+	    throw "You must pass your app key when you instantiate Pusher.";
 	  }
 	}
 
@@ -261,7 +259,7 @@ var Pusher =
 
 	/* WEBPACK VAR INJECTION */(function(global) {var XHR = __webpack_require__(2);
 
-	module.exports = Util = {
+	module.exports = {
 	  now: function() {
 	    if (Date.now) {
 	      return Date.now();
@@ -1399,7 +1397,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getStreamingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -1667,7 +1665,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getXHR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1803,7 +1801,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getXDR = function(method, url) {
+	module.exports = function(method, url) {
 	  return new HTTPRequest(hooks, method, url);
 	};
 
@@ -1833,7 +1831,7 @@ var Pusher =
 	  }
 	};
 
-	module.exports = getPollingSocket = function(url) {
+	module.exports = function(url) {
 	  return new HTTPSocket(hooks, url);
 	};
 
@@ -2541,7 +2539,7 @@ var Pusher =
 	var IfStrategy = __webpack_require__(42);
 	var FirstConnectedStrategy = __webpack_require__(43);
 
-	module.exports = StrategyBuilder = {
+	module.exports = {
 	  /** Transforms a JSON scheme to a strategy tree.
 	   *
 	   * @param {Array} scheme JSON strategy scheme
@@ -4204,7 +4202,11 @@ var Pusher =
 	  var previousState = this.state;
 	  this.state = newState;
 	  if (previousState !== newState) {
-	    Logger.debug('State changed', previousState + ' -> ' + newState);
+	    var newStateDescription = newState;
+	    if (newState === "connected") {
+	      newStateDescription += " with new socket ID " + data.socket_id;
+	    }
+	    Logger.debug('State changed', previousState + ' -> ' + newStateDescription);
 	    this.timeline.info({ state: newState, params: data });
 	    this.emit('state_change', { previous: previousState, current: newState });
 	    this.emit(newState, data);

--- a/src/http/http_polling_socket.js
+++ b/src/http/http_polling_socket.js
@@ -19,6 +19,6 @@ var hooks = {
   }
 };
 
-module.exports = getPollingSocket = function(url) {
+module.exports = function(url) {
   return new HTTPSocket(hooks, url);
 };

--- a/src/http/http_streaming_socket.js
+++ b/src/http/http_streaming_socket.js
@@ -15,6 +15,6 @@ var hooks = {
   }
 };
 
-module.exports = getStreamingSocket = function(url) {
+module.exports = function(url) {
   return new HTTPSocket(hooks, url);
 };

--- a/src/http/http_xdomain_request.js
+++ b/src/http/http_xdomain_request.js
@@ -31,6 +31,6 @@ var hooks = {
   }
 };
 
-module.exports = getXDR = function(method, url) {
+module.exports = function(method, url) {
   return new HTTPRequest(hooks, method, url);
 };

--- a/src/http/http_xhr_request.js
+++ b/src/http/http_xhr_request.js
@@ -29,6 +29,6 @@ var hooks = {
   }
 };
 
-module.exports = getXHR = function(method, url) {
+module.exports = function(method, url) {
   return new HTTPRequest(hooks, method, url);
 };

--- a/src/strategies/strategy_builder.js
+++ b/src/strategies/strategy_builder.js
@@ -10,7 +10,7 @@ var DelayedStrategy = require('./delayed_strategy');
 var IfStrategy = require('./if_strategy');
 var FirstConnectedStrategy = require('./first_connected_strategy');
 
-module.exports = StrategyBuilder = {
+module.exports = {
   /** Transforms a JSON scheme to a strategy tree.
    *
    * @param {Array} scheme JSON strategy scheme

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,6 @@
 var XHR = require('pusher-websocket-iso-externals-node/xhr');
 
-module.exports = Util = {
+module.exports = {
   now: function() {
     if (Date.now) {
       return Date.now();


### PR DESCRIPTION
Not sure if this is the right approach...  Ran into some issues with React@0.22 recent update requiring strict mode, and getting failures on the named `module.exports`.  Replaced all occurrences that react native was complaining about, and regenerated the dist with the build script.
